### PR TITLE
ci: Implement a release PR workflow on GHA

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,57 @@
+name: Open a release PR
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+        type: string
+
+env:
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  make-release-pr:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [neptune]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+            profile: minimal
+      - name: Get current version
+        id: get-version
+        run: |
+          echo "CURRENT_VERSION=$(./script/get_current_version.sh ${{ matrix.package }})" >> $GITHUB_ENV
+      - name: Check version
+        id: version-check
+        run: |
+          IFS='.' read -ra INPUT_VERSION <<< "${{ github.event.inputs.version }}"
+          IFS='.' read -ra CURRENT_VERSION <<< "${{ env.CURRENT_VERSION }}"
+
+          for i in "${!INPUT_VERSION[@]}"; do
+            if (( INPUT_VERSION[i] > CURRENT_VERSION[i] )); then
+              echo "Input version is larger than current version. Proceeding..."
+              exit 0
+            elif (( INPUT_VERSION[i] < CURRENT_VERSION[i] )); then
+              echo "Input version is not larger than current version. Failing..."
+              exit 1
+            fi
+          done
+
+          echo "Input version is equal to current version. Failing..."
+          exit 1
+
+      - name: Install cargo-release
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-release
+
+      - uses: cargo-bins/release-pr@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ inputs.version }}
+          pr-template-file: .github/release-pr-template.ejs
+          crate-name: "neptune" 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,6 +87,7 @@ jobs:
       with:
         toolchain: stable
         override: true
+    - uses: Swatinem/rust-cache@v2
     - name: Install cargo-msrv
       run: cargo install cargo-msrv
     - name: Check Rust MSRV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,25 +19,25 @@ edition = "2021"
 rust-version = "1.62.1"
 
 [dependencies]
-blake2s_simd = "1.0.0"
+blake2s_simd = "1.0.1"
 ff = "0.13.0"
 group = "0.13.0"
 rand_core = "0.6"
 byteorder = "1"
-thiserror = "1.0.10"
+thiserror = "1.0.44"
 serde = { version = "1.0", features = ["derive"] }
 fs2 = { version = "0.4.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-memmap2 = "0.5.8"
+memmap2 = "0.5.10"
 
 [dev-dependencies]
 hex-literal = "0.4"
 criterion = "0.4.0"
-tempfile = "3.1.0"
-subtle = "2.2.1"
-temp-env = "0.3.0"
-itertools = "0.10.0"
+tempfile = "3.6.0"
+subtle = "2.5.0"
+temp-env = "0.3.4"
+itertools = "0.10.5"
 blstrs = "0.7.0"
 rand_xorshift = "0.3.0"
 sha2 = "0.10.7"
@@ -60,4 +60,4 @@ harness = false
 [build-dependencies]
 blstrs = { version = "0.7.0", features = ["__private_bench"] }
 ec-gpu-gen = { version = "0.7.0" }
-rustversion = "1.0.6"
+rustversion = "1.0.14"

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    pull-request-branch-name:
+      separator: "-"
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/release-pr-template.ejs
+++ b/release-pr-template.ejs
@@ -1,0 +1,23 @@
+This is a release PR for version **<%= version.actual %>**<%
+    if (version.actual != version.desired) {
+%> (performing a <%= version.desired %> bump).<%
+    } else {
+%>.<%
+    }
+%>
+
+You will still need to manually publish the cargo crate:
+
+```
+$ make VERSION=<%= version.actual %> release
+```
+
+<% if (pr.releaseNotes) { %>
+---
+
+_Edit release notes into the section below:_
+
+<!-- do not change or remove this heading -->
+### Release notes
+
+<% } %>


### PR DESCRIPTION
This uses:
- [cargo-release](https://github.com/crate-ci/cargo-release) and the [release-pr action](https://github.com/cargo-bins/release-pr),
- in order to create a PR that will let everyone agree to the minute details of a release,
- in the current form of the PR, once it is approved and merged, the last step of the release (publishing the crate) is done in a `Makefile` by anyone [equipped with the correct crates.io token](https://doc.rust-lang.org/cargo/reference/publishing.html),
- the command to run to enact publication is listed in the release PR,