### PR TITLE
ci: prevent CI from firing on pushes to the merge queue branches

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,9 @@ name: Rust
 on:
   merge_group:
   push:
-    branches-ignored: [main]
+    branches-ignore: 
+      - "gh-readonly-queue/**"
+      - "main"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]


### PR DESCRIPTION
See also 
https://github.com/lurk-lab/lurk-rs/pull/566
https://github.com/lurk-lab/neptune/pull/216