### PR TITLE
chore: Update dependencies to use workspace versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,10 @@ members = [
     "crates/bellpepper-core",
     "crates/bellpepper"
 ]
+
+[workspace.dependencies]
+blstrs = { version = "0.7.0"}
+ff = "0.13.0"
+group = "0.13.0"
+rand_core = "0.6"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/bellpepper-core/Cargo.toml
+++ b/crates/bellpepper-core/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/lurk-lab/bellpepper"
 version = "0.2.0"
 readme = "../../README.md"
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.64.0"
 
 [dependencies]
 blake2s_simd = "1.0.1"

--- a/crates/bellpepper-core/Cargo.toml
+++ b/crates/bellpepper-core/Cargo.toml
@@ -17,19 +17,19 @@ rust-version = "1.62.1"
 
 [dependencies]
 blake2s_simd = "1.0.1"
-ff = "0.13.0"
-group = "0.13.0"
-rand_core = "0.6"
+ff = { workspace = true }
+group = { workspace = true }
+rand_core = { workspace = true}
 byteorder = "1"
 thiserror = "1.0.44"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 fs2 = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 hex-literal = "0.4"
 criterion = "0.4.0"
 subtle = "2.5.0"
-blstrs = "0.7.0"
+blstrs = { workspace = true }
 rand_xorshift = "0.3.0"
 sha2 = "0.10.7"
 

--- a/crates/bellpepper/Cargo.toml
+++ b/crates/bellpepper/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/lurk-lab/bellpepper"
 version = "0.2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.64.0"
 
 [dependencies]
 blake2s_simd = "1.0.1"

--- a/crates/bellpepper/Cargo.toml
+++ b/crates/bellpepper/Cargo.toml
@@ -17,19 +17,19 @@ rust-version = "1.62.1"
 
 [dependencies]
 blake2s_simd = "1.0.1"
-ff = "0.13.0"
-group = "0.13.0"
-rand_core = "0.6"
+ff = { workspace = true }
+group = { workspace = true }
+rand_core = { workspace = true }
 byteorder = "1"
 thiserror = "1.0.44"
-serde = { version = "1.0", features = ["derive"] }
+serde = { workspace = true }
 fs2 = { version = "0.4.3", optional = true }
 bellpepper-core = { version = "0.2.0", path = "../bellpepper-core" }
 
 [dev-dependencies]
 hex-literal = "0.4"
 subtle = "2.5.0"
-blstrs = "0.7.0"
+blstrs = { workspace = true }
 rand_xorshift = "0.3.0"
 sha2 = "0.10.7"
 


### PR DESCRIPTION
- Standardized dependencies across `bellpepper-core` and `bellpepper` by using the workspace version instead of specific versions.
- Updated `ff`, `group`, `rand_core`, `serde`, and `blstrs` dependencies in both `bellpepper-core` and `bellpepper` to reflect the changes in workspace versions.
- Introduced new dependencies `blstrs`, `ff`, `group`, `rand_core`, and `serde` with derive features to the workspace.