### PR TITLE
chore: Implement weekly Dependabot checks for dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    pull-request-branch-name:
+      separator: "-"
+    schedule:
+      interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
- Implement Dependabot to automatically check for outdated dependencies and GitHub Actions.
- use grouped updates: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/
- Set a schedule for weekly Dependabot checks.