### PR TITLE
chore: tune Clippy settings to enfore markdown in doc comments + fix

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -5,7 +5,8 @@
 # <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 # TODO: add support for --all-features
 xclippy = [
-    "clippy", "--all-targets", "--",
+    "clippy", "--workspace", "--all-targets", "--",
     "-Wclippy::all",
     "-Wclippy::disallowed_methods",
+    "-Wclippy::doc_markdown",
 ]

--- a/crates/bellpepper-core/src/constraint_system.rs
+++ b/crates/bellpepper-core/src/constraint_system.rs
@@ -128,7 +128,7 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
         Namespace(self.get_root(), Default::default())
     }
 
-    /// Most implementations of ConstraintSystem are not 'extensible': they won't implement a specialized
+    /// Most implementations of `ConstraintSystem` are not 'extensible': they won't implement a specialized
     /// version of `extend` and should therefore also keep the default implementation of `is_extensible`
     /// so callers which optionally make use of `extend` can know to avoid relying on it when unimplemented.
     fn is_extensible() -> bool {
@@ -148,7 +148,7 @@ pub trait ConstraintSystem<Scalar: PrimeField>: Sized + Send {
     }
 
     /// Determines if the current `ConstraintSystem` instance is a witness generator.
-    /// ConstraintSystems that are witness generators need not assemble the actual constraints. Rather, they exist only
+    /// `ConstraintSystems` that are witness generators need not assemble the actual constraints. Rather, they exist only
     /// to efficiently create a witness.
     ///
     /// # Returns
@@ -331,7 +331,7 @@ impl<'a, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> Drop for Namespace<'a
     }
 }
 
-/// Convenience implementation of ConstraintSystem<Scalar> for mutable references to
+/// Convenience implementation of `ConstraintSystem`<Scalar> for mutable references to
 /// constraint systems.
 impl<'cs, Scalar: PrimeField, CS: ConstraintSystem<Scalar>> ConstraintSystem<Scalar>
     for &'cs mut CS


### PR DESCRIPTION
- Modified the `xclippy` alias settings in the `.cargo/config` file to require markdown in doc comments
- Updated commenting styles in `constraint_system.rs` file for improved doc