### PR TITLE
chore: Adjust MSRV for bellpepper

### DIFF
--- a/crates/bellpepper/Cargo.toml
+++ b/crates/bellpepper/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/lurk-lab/bellpepper"
 version = "0.2.1"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.72.0"
+rust-version = "1.66.0"
 
 [dependencies]
 bellpepper-core = { version = "0.2", path = "../bellpepper-core" }


### PR DESCRIPTION
- Downgraded the minimum required Rust version for the Bellpepper crate to increase compatibility.