### PR TITLE
fix Indexer's iter_mut

### DIFF
--- a/crates/bellpepper-core/src/lc.rs
+++ b/crates/bellpepper-core/src/lc.rs
@@ -66,8 +66,8 @@ impl<T> Indexer<T> {
         self.values.iter().map(|(key, value)| (key, value))
     }
 
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&mut usize, &mut T)> + '_ {
-        self.values.iter_mut().map(|(key, value)| (key, value))
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&usize, &mut T)> + '_ {
+        self.values.iter_mut().map(|(key, value)| (&*key, value))
     }
 
     pub fn insert_or_update<F, G>(&mut self, key: usize, insert: F, update: G)


### PR DESCRIPTION
The type Item returned by `iter_mut` should be `(&usize, &mut T)` instead of `(&mut usize, &mut T)`, because the elements in `Indexer`'s `values` need to be sorted according to key, so that binary search is effective when `insert_or_update`, so we cannot allow the key to be changed.