### PR TITLE
add public getters to WitnessCS fields to permit arecibo refactor

### DIFF
--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -47,8 +47,21 @@ where
     Scalar: PrimeField,
 {
     // Assignments of variables
-    pub input_assignment: Vec<Scalar>,
-    pub aux_assignment: Vec<Scalar>,
+    pub(crate) input_assignment: Vec<Scalar>,
+    pub(crate) aux_assignment: Vec<Scalar>,
+}
+
+impl<Scalar> WitnessCS<Scalar>
+where
+    Scalar: PrimeField,
+{
+    pub fn input_assignment(&self) -> &Vec<Scalar> {
+        &self.input_assignment
+    }
+
+    pub fn aux_assignment(&self) -> &Vec<Scalar> {
+        &self.aux_assignment
+    }
 }
 
 impl<Scalar> ConstraintSystem<Scalar> for WitnessCS<Scalar>
@@ -164,15 +177,5 @@ where
 
     fn aux_slice(&self) -> &[Scalar] {
         &self.aux_assignment
-    }
-}
-
-impl<Scalar: PrimeField> WitnessCS<Scalar> {
-    pub fn scalar_inputs(&self) -> Vec<Scalar> {
-        self.input_assignment.clone()
-    }
-
-    pub fn scalar_aux(&self) -> Vec<Scalar> {
-        self.aux_assignment.clone()
     }
 }

--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -180,15 +180,19 @@ where
     }
 }
 
-#[deprecated(
-    since = "0.4.0",
-    note = "Deprecated for performance; use `input_assignment` and `aux_assignment` to avoid data cloning."
-)]
 impl<Scalar: PrimeField> WitnessCS<Scalar> {
+    #[deprecated(
+        since = "0.4.0",
+        note = "Deprecated for performance; use the `input_assignment` method to avoid data cloning."
+    )]
     pub fn scalar_inputs(&self) -> Vec<Scalar> {
         self.input_assignment.clone()
     }
 
+    #[deprecated(
+        since = "0.4.0",
+        note = "Deprecated for performance; use `aux_assignment` method to avoid data cloning."
+    )]
     pub fn scalar_aux(&self) -> Vec<Scalar> {
         self.aux_assignment.clone()
     }

--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -55,11 +55,11 @@ impl<Scalar> WitnessCS<Scalar>
 where
     Scalar: PrimeField,
 {
-    pub fn scalar_inputs(&self) -> &[Scalar] {
+    pub fn input_assignment(&self) -> &[Scalar] {
         &self.input_assignment
     }
 
-    pub fn scalar_aux(&self) -> &[Scalar] {
+    pub fn aux_assignment(&self) -> &[Scalar] {
         &self.aux_assignment
     }
 }
@@ -177,5 +177,19 @@ where
 
     fn aux_slice(&self) -> &[Scalar] {
         &self.aux_assignment
+    }
+}
+
+#[deprecated(
+    since = "0.4.0",
+    note = "Deprecated for performance; use `input_assignment` and `aux_assignment` to avoid data cloning."
+)]
+impl<Scalar: PrimeField> WitnessCS<Scalar> {
+    pub fn scalar_inputs(&self) -> Vec<Scalar> {
+        self.input_assignment.clone()
+    }
+
+    pub fn scalar_aux(&self) -> Vec<Scalar> {
+        self.aux_assignment.clone()
     }
 }

--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -47,8 +47,8 @@ where
     Scalar: PrimeField,
 {
     // Assignments of variables
-    pub(crate) input_assignment: Vec<Scalar>,
-    pub(crate) aux_assignment: Vec<Scalar>,
+    pub input_assignment: Vec<Scalar>,
+    pub aux_assignment: Vec<Scalar>,
 }
 
 impl<Scalar> ConstraintSystem<Scalar> for WitnessCS<Scalar>

--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -55,11 +55,11 @@ impl<Scalar> WitnessCS<Scalar>
 where
     Scalar: PrimeField,
 {
-    pub fn input_assignment(&self) -> &Vec<Scalar> {
+    pub fn scalar_inputs(&self) -> &[Scalar] {
         &self.input_assignment
     }
 
-    pub fn aux_assignment(&self) -> &Vec<Scalar> {
+    pub fn scalar_aux(&self) -> &[Scalar] {
         &self.aux_assignment
     }
 }


### PR DESCRIPTION
Per this discussion: https://github.com/lurk-lab/arecibo/issues/77#issuecomment-1787358390 

This change makes the WitnessCS fields public, enabling [arecibo's SatisfyingAssignment](https://github.com/lurk-lab/arecibo/blob/dev/src/bellpepper/solver.rs#L9) to be reimplemented as a type alias.