### PR TITLE
feat: Enhance boolean operations in bellpepper crate

### DIFF
--- a/crates/bellpepper/Cargo.toml
+++ b/crates/bellpepper/Cargo.toml
@@ -21,6 +21,7 @@ byteorder = { workspace = true }
 ff = { workspace = true }
 
 [dev-dependencies]
+proptest = "1.3.1"
 blake2s_simd = { workspace = true }
 hex-literal = "0.4"
 blstrs = { workspace = true }

--- a/crates/bellpepper/src/gadgets/boolean_utils.rs
+++ b/crates/bellpepper/src/gadgets/boolean_utils.rs
@@ -48,8 +48,8 @@ macro_rules! and {
 
 }
 
-/// Allocate a Boolean which is true if and only if `num` is zero.
-pub fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
+// Allocate a Boolean which is true if and only if `num` is zero.
+fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
     mut cs: CS,
     num: &Num<F>,
 ) -> Result<Boolean, SynthesisError> {

--- a/crates/bellpepper/src/gadgets/boolean_utils.rs
+++ b/crates/bellpepper/src/gadgets/boolean_utils.rs
@@ -1,0 +1,195 @@
+use bellpepper_core::{
+    boolean::{AllocatedBit, Boolean},
+    num::Num,
+    ConstraintSystem, SynthesisError,
+};
+use ff::PrimeField;
+
+// Returns a Boolean which is true if any of its arguments are true.
+#[macro_export]
+macro_rules! or {
+    ($cs:expr, $a:expr, $b:expr) => {
+        Boolean::or(
+            bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("{} or {}", stringify!($a), stringify!($b))),
+            $a,
+            $b,
+        )
+    };
+    ($cs:expr, $a:expr, $b:expr, $c:expr, $($x:expr),+) => {{
+        let or_tmp_cs_ =  bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("or({})", stringify!(vec![$a, $b, $c, $($x),*])));
+        super::or_v(or_tmp_cs_, &[$a, $b, $c, $($x),*])
+    }};
+    ($cs:expr, $a:expr, $($x:expr),+) => {{
+        let mut or_tmp_cs_ =  bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("or {}", stringify!(vec![$a, $($x),*])));
+        let or_tmp_ = or!(or_tmp_cs_, $($x),*)?;
+        or!(or_tmp_cs_, $a, &or_tmp_)
+    }};
+}
+
+// Returns a Boolean which is true if all of its arguments are true.
+#[macro_export]
+macro_rules! and {
+    ($cs:expr, $a:expr, $b:expr) => {
+        Boolean::and(
+            bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("{} and {}", stringify!($a), stringify!($b))),
+            $a,
+            $b,
+        )
+    };
+    ($cs:expr, $a:expr, $b:expr, $c:expr, $($x:expr),+) => {{
+        let and_tmp_cs_ = bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("and({})", stringify!([$a, $b, $c, $($x),*])));
+        super::and_v(and_tmp_cs_, &[$a, $b, $c, $($x),*])
+    }};
+    ($cs:ident, $a:expr, $($x:expr),+) => {{
+        let mut and_tmp_cs_ =  bellpepper_core::ConstraintSystem::namespace(&mut $cs, || format!("and({})", stringify!([$a, $($x),*])));
+        let and_tmp_ = and!(and_tmp_cs_, $($x),*)?;
+        and!(and_tmp_cs_, $a, &and_tmp_)
+    }};
+
+}
+
+/// Allocate a Boolean which is true if and only if `num` is zero.
+pub fn alloc_num_is_zero<CS: ConstraintSystem<F>, F: PrimeField>(
+    mut cs: CS,
+    num: &Num<F>,
+) -> Result<Boolean, SynthesisError> {
+    let num_value = num.get_value();
+    let x = num_value.unwrap_or(F::ZERO);
+    let is_zero = num_value.map(|n| n == F::ZERO);
+
+    // result = (x == 0)
+    let result = AllocatedBit::alloc(cs.namespace(|| "x = 0"), is_zero)?;
+
+    // result * x = 0
+    // This means that at least one of result or x is zero.
+    cs.enforce(
+        || "result or x is 0",
+        |lc| lc + result.get_variable(),
+        |_| num.lc(F::ONE),
+        |lc| lc,
+    );
+
+    // Inverse of `x`, if it exists, otherwise one.
+    let q = cs.alloc(
+        || "q",
+        || {
+            let tmp = x.invert();
+            if tmp.is_some().into() {
+                Ok(tmp.unwrap())
+            } else {
+                Ok(F::ONE)
+            }
+        },
+    )?;
+
+    // (x + result) * q = 1.
+    // This enforces that x and result are not both 0.
+    cs.enforce(
+        || "(x + result) * q = 1",
+        |_| num.lc(F::ONE) + result.get_variable(),
+        |lc| lc + q,
+        |lc| lc + CS::one(),
+    );
+
+    // Taken together, these constraints enforce that exactly one of `x` and `result` is 0.
+    // Since result is constrained to be boolean, that means `result` is true iff `x` is 0.
+
+    Ok(Boolean::Is(result))
+}
+
+/// Variadic or.
+pub fn or_v<CS: ConstraintSystem<F>, F: PrimeField>(
+    cs: CS,
+    v: &[&Boolean],
+) -> Result<Boolean, SynthesisError> {
+    assert!(
+        v.len() >= 4,
+        "with less than 4 elements, or_v is more expensive than repeated or"
+    );
+
+    or_v_unchecked_for_optimization(cs, v)
+}
+
+/// Unchecked variadic or.
+pub fn or_v_unchecked_for_optimization<CS: ConstraintSystem<F>, F: PrimeField>(
+    mut cs: CS,
+    v: &[&Boolean],
+) -> Result<Boolean, SynthesisError> {
+    // Count the number of true values in v.
+    let count_true = v.iter().fold(Num::zero(), |acc, b| {
+        acc.add_bool_with_coeff(CS::one(), b, F::ONE)
+    });
+
+    // If the number of true values is zero, then none of the values is true.
+    // Therefore, nor(v0, v1, ..., vn) is true.
+    let nor = alloc_num_is_zero(&mut cs.namespace(|| "nor"), &count_true)?;
+
+    Ok(nor.not())
+}
+
+/// Variadic and.
+pub fn and_v<CS: ConstraintSystem<F>, F: PrimeField>(
+    mut cs: CS,
+    v: &[&Boolean],
+) -> Result<Boolean, SynthesisError> {
+    assert!(
+        v.len() >= 4,
+        "with less than 4 elements, and_v is more expensive than repeated and"
+    );
+
+    // Count the number of false values in v.
+    let count_false = v.iter().fold(Num::zero(), |acc, b| {
+        acc.add_bool_with_coeff(CS::one(), &b.not(), F::ONE)
+    });
+
+    // If the number of false values is zero, then all of the values are true.
+    // Therefore, and(v0, v1, ..., vn) is true.
+    let and = alloc_num_is_zero(&mut cs.namespace(|| "nor_of_nots"), &count_false)?;
+
+    Ok(and)
+}
+
+#[cfg(test)]
+mod tests {
+    use bellpepper_core::{boolean::Boolean, test_cs::TestConstraintSystem};
+    use blstrs::Scalar as Fr;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        // needs to return Result because the macros use ?.
+        fn test_and_or_v((x0, x1, x2, x3, x4) in any::<(bool, bool, bool, bool, bool)>()) {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a = Boolean::Constant(x0);
+            let b = Boolean::Constant(x1);
+            let c = Boolean::Constant(x2);
+            let d = Boolean::Constant(x3);
+            let e = Boolean::Constant(x4);
+
+            let and0 = and!(cs, &a, &b, &c).unwrap();
+            let and1 = and!(cs, &a, &b, &c, &d).unwrap();
+            let and2 = and!(cs, &a, &b, &c, &d, &e).unwrap();
+
+            let or0 = or!(cs, &a, &b, &c).unwrap();
+            let or1 = or!(cs, &a, &b, &c, &d).unwrap();
+            let or2 = or!(cs, &a, &b, &c, &d, &e).unwrap();
+
+            let expected_and0 = x0 && x1 && x2;
+            let expected_and1 = x0 && x1 && x2 && x3;
+            let expected_and2 = x0 && x1 && x2 && x3 && x4;
+
+            let expected_or0 = x0 || x1 || x2;
+            let expected_or1 = x0 || x1 || x2 || x3;
+            let expected_or2 = x0 || x1 || x2 || x3 || x4;
+
+            assert_eq!(expected_and0, and0.get_value().unwrap());
+            assert_eq!(expected_and1, and1.get_value().unwrap());
+            assert_eq!(expected_and2, and2.get_value().unwrap());
+            assert_eq!(expected_or0, or0.get_value().unwrap());
+            assert_eq!(expected_or1, or1.get_value().unwrap());
+            assert_eq!(expected_or2, or2.get_value().unwrap());
+            assert!(cs.is_satisfied());
+        }
+    }
+}

--- a/crates/bellpepper/src/gadgets/mod.rs
+++ b/crates/bellpepper/src/gadgets/mod.rs
@@ -7,6 +7,8 @@ pub mod multipack;
 pub use bellpepper_core::num;
 pub mod sha256;
 pub mod uint32;
+#[macro_use]
+pub mod boolean_utils;
 
 use bellpepper_core::SynthesisError;
 

--- a/crates/bellpepper/src/gadgets/mod.rs
+++ b/crates/bellpepper/src/gadgets/mod.rs
@@ -1,14 +1,15 @@
 //! Self-contained sub-circuit implementations for various primitives.
 pub mod blake2s;
 pub use bellpepper_core::boolean;
+#[macro_use]
+pub mod boolean_utils;
 pub mod lookup;
 pub mod multieq;
 pub mod multipack;
+pub mod negative_num;
 pub use bellpepper_core::num;
 pub mod sha256;
 pub mod uint32;
-#[macro_use]
-pub mod boolean_utils;
 
 use bellpepper_core::SynthesisError;
 

--- a/crates/bellpepper/src/gadgets/negative_num.rs
+++ b/crates/bellpepper/src/gadgets/negative_num.rs
@@ -1,0 +1,24 @@
+use bellpepper_core::{boolean::Boolean, num::AllocatedNum, ConstraintSystem, SynthesisError};
+use ff::PrimeFieldBits;
+
+/// Allocate Boolean for predicate "num is negative".
+/// We have that a number is defined to be negative if the parity bit (the
+/// least significant bit) is odd after doubling, meaning that the field element
+/// (after doubling) is larger than the underlying prime p that defines the
+/// field, then a modular reduction must have been carried out, changing the parity that
+/// should be even (since we multiplied by 2) to odd. In other words, we define
+/// negative numbers to be those field elements that are larger than p/2.
+pub fn allocate_is_negative<F: PrimeFieldBits, CS: ConstraintSystem<F>>(
+    mut cs: CS,
+    num: &AllocatedNum<F>,
+) -> Result<Boolean, SynthesisError> {
+    let double_num = num.add(&mut cs.namespace(|| "double num"), num)?;
+    let double_num_bits = double_num
+        .to_bits_le_strict(&mut cs.namespace(|| "double num bits"))
+        .unwrap();
+
+    let lsb_2num = double_num_bits.get(0);
+    let num_is_negative = lsb_2num.unwrap();
+
+    Ok(num_is_negative.clone())
+}


### PR DESCRIPTION
- Introduce a new module for variadic boolean utility functions, - Implement new variadic versions of boolean OR and AND operations, i.e., `or_v`, `or_v_unchecked_for_optimization`, `and_v`. - Integrate boolean `or!` and `and!` macros and add allocation function to verify zero values & arity.
- Conduct tests for the added and/or macros and various utility functions.

Imported from https://github.com/lurk-lab/lurk-rs/issues/874