### PR TITLE
some WitnessCS utility functions

### DIFF
--- a/crates/bellpepper/src/util_cs/witness_cs.rs
+++ b/crates/bellpepper/src/util_cs/witness_cs.rs
@@ -62,6 +62,26 @@ where
     pub fn aux_assignment(&self) -> &[Scalar] {
         &self.aux_assignment
     }
+
+    pub fn with_capacity(input_size: usize, aux_size: usize) -> Self {
+        let input_assignment = Vec::with_capacity(input_size);
+        let aux_assignment = Vec::with_capacity(aux_size);
+        Self {
+            input_assignment,
+            aux_assignment,
+        }
+    }
+
+    pub fn from_assignments(input_assignment: Vec<Scalar>, aux_assignment: Vec<Scalar>) -> Self {
+        Self {
+            input_assignment,
+            aux_assignment,
+        }
+    }
+
+    pub fn to_assignments(self) -> (Vec<Scalar>, Vec<Scalar>) {
+        (self.input_assignment, self.aux_assignment)
+    }
 }
 
 impl<Scalar> ConstraintSystem<Scalar> for WitnessCS<Scalar>


### PR DESCRIPTION
`to_assignments` to be able to retrieve input/aux vectors from the CS (and its inverse `from_assignments` ) and `with_capacity` to build witnesses of known sizes