### PR TITLE
chore: make bellpepper depend on released version of the core package

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,10 +3,10 @@ name: Rust
 on:
   merge_group:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/crates/bellpepper/Cargo.toml
+++ b/crates/bellpepper/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.66.0"
 
 [dependencies]
-bellpepper-core = { version = "0.4", path = "../bellpepper-core" }
+bellpepper-core = { version = "0.4" }
 byteorder = { workspace = true }
 ff = { workspace = true }
 


### PR DESCRIPTION
This helps make sure our downstream projects don't disagree on bellpepper-core versions.
This PR will need three companion PRs:
- [x] neptune: https://github.com/lurk-lab/neptune/pull/273
- [x] arecibo: https://github.com/lurk-lab/arecibo/pull/338
- [x] lurk: https://github.com/lurk-lab/lurk-rs/pull/1157