### PR TITLE
Fix handling of None in Num::add

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,9 @@ jobs:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
+    - uses: ./.github/actions/install-deps
+      with:
+        packages: 'pkg-config libssl-dev protobuf-compiler libprotobuf-dev'
     - name: Patch Cargo.toml
       working-directory: ${{ github.workspace }}/lurk
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,7 @@ jobs:
       run: |
         echo "[patch.'https://github.com/lurk-lab/bellpepper']" >> Cargo.toml
         echo "bellpepper = { path='../bellpepper/crates/bellpepper' }" >> Cargo.toml
+        echo "[patch.crates-io]" >> Cargo.toml
         echo "bellpepper-core = { path='../bellpepper/crates/bellpepper-core' }" >> Cargo.toml
     - name: Check Lurk-rs types don't break spectacularly
       working-directory: ${{ github.workspace }}/lurk

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,6 +46,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        repository: lurk-lab/ci-workflows
+    - uses: ./.github/actions/ci-env
+    - uses: ./.github/actions/install-deps
+      with:
+        packages: 'pkg-config libssl-dev protobuf-compiler libprotobuf-dev'
+    - uses: actions/checkout@v4
+      with:
         path: ${{ github.workspace }}/bellpepper
     - uses: actions/checkout@v4
       with:
@@ -54,9 +61,6 @@ jobs:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - uses: lurk-lab/ci-workflows/.github/actions/install-deps
-      with:
-        packages: 'pkg-config libssl-dev protobuf-compiler libprotobuf-dev'
     - name: Patch Cargo.toml
       working-directory: ${{ github.workspace }}/lurk
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         submodules: recursive
     - uses: dtolnay/rust-toolchain@stable
     - uses: Swatinem/rust-cache@v2
-    - uses: ./.github/actions/install-deps
+    - uses: lurk-lab/ci-workflows/.github/actions/install-deps
       with:
         packages: 'pkg-config libssl-dev protobuf-compiler libprotobuf-dev'
     - name: Patch Cargo.toml

--- a/crates/bellpepper-core/src/gadgets/num.rs
+++ b/crates/bellpepper-core/src/gadgets/num.rs
@@ -520,8 +520,7 @@ impl<Scalar: PrimeField> Num<Scalar> {
                 tmp.add_assign(&v2);
                 Some(tmp)
             }
-            (Some(v), None) | (None, Some(v)) => Some(v),
-            (None, None) => None,
+            _ => None,
         };
 
         Num { value, lc }
@@ -569,6 +568,23 @@ mod test {
         AllocatedNum::alloc_infallible(&mut cs, || Fr::ONE);
 
         assert!(cs.get("num") == Fr::ONE);
+    }
+
+    #[test]
+    fn test_num_partial_addition() {
+        let a = Num::<Fr>::zero();
+        let b = Num::<Fr> {
+            value: None,
+            lc: Default::default(),
+        };
+        let c = a.clone().add(&b);
+        assert!(c.value.is_none());
+        let c = b.clone().add(&a);
+        assert!(c.value.is_none());
+        let c = b.clone().add(&b);
+        assert!(c.value.is_none());
+        let c = a.clone().add(&a);
+        assert!(c.value == Some(Fr::ZERO));
     }
 
     #[test]


### PR DESCRIPTION
Currently, adding a `Num` with a `None` value and a `Some(v)` value will make the result have value equal to `Some(v)` instead of `None`.

When used with MetricCS (or any CS that doesn't fully allocate values), this means calculations involving constant `Num`s become "valued" which can cause issues when downstream code calls `.get_value()` and doesn't receive the expected `None` (instead receiving some constant value). This PR fixes the behavior and adds a short test.

`Num::add_bool_with_coeff` and other functions in `AllocatedNum` don't suffer from this same issue.